### PR TITLE
extend possible_keys to load keys from subdirectories

### DIFF
--- a/ptool/configure.py
+++ b/ptool/configure.py
@@ -1,8 +1,9 @@
+import fnmatch
 import glob
 import os
-import questionary
 import subprocess
-import fnmatch
+
+import questionary
 from ruamel.yaml import YAML
 
 BASEPATH_SCRIPTS = os.path.dirname(os.path.abspath(__file__))
@@ -264,7 +265,7 @@ class Config(dict):
             if ssh_key_config_action == "Reuse an existing ssh-key":
                 possible_keys = [
                     os.path.join(r, _f)
-                    for r,d,f, in os.walk(ssh_dir)
+                    for r, d, f, in os.walk(ssh_dir)
                     for _f in fnmatch.filter(f, "id_*[!\\.pub]")
                 ]
 


### PR DESCRIPTION
The current logic for possible_keys in configure.py shows all the entries (either files or sub-folders) which do not end with ".pub" extension. Some of these entries include items which are not valid ssh keys. Also it not traverse sub-folders (if there are any) to pin-point to a ssh key.

Here is quick interactive exploration of the current logic:

```python
>>> # "Reuse an existing ssh-key" logic (from [configure.py](https://configure.py/))
>>> import os, glob, fnmatch, pprint
>>> ssh_dir = os.path.expanduser("~/.ssh")
>>> possible_keys = glob.glob(f"{ssh_dir}/*[!\\.pub]")
>>> pprint.pprint(possible_keys)
['/Users/pasili001/.ssh/id_ed25519',
 '/Users/pasili001/.ssh/config~',
 '/Users/pasili001/.ssh/known_hosts.old',
 '/Users/pasili001/.ssh/config',
 '/Users/pasili001/.ssh/dkrz',
 '/Users/pasili001/.ssh/hlrn',
 '/Users/pasili001/.ssh/known_hosts']
>>> # clearly some of the entries are not relavent.
>>> # Adjusting possible_keys
>>> possible_keys = glob.glob(f"{ssh_dir}/id_*[!\\.pub]")
>>> pprint.pprint(possible_keys)
['/Users/pasili001/.ssh/id_ed25519']
>>> # better but too few entries. incomplete listings.
>>> # Adjusting possible_keys
>>> possible_keys = glob.glob(f"{ssh_dir}/*/id_*[!\\.pub]")
>>> pprint.pprint(possible_keys)
['/Users/pasili001/.ssh/dkrz/id_ed25519',
 '/Users/pasili001/.ssh/dkrz/id_ed25519_dkrz',
 '/Users/pasili001/.ssh/hlrn/id_rsa_hlrn',
 '/Users/pasili001/.ssh/github/id_ed25519']
>>> # much better, finds all relevant keys from sub-dirs but
>>> # misses the top-level key.
>>> # Re-formulating possible_keys logic
>>> possible_keys = [
    os.path.join(r, _f)
    for r,d,f in os.walk(ssh_dir)
    for _f in fnmatch.filter(f, "id_*[!\\.pub]")
]
>>> pprint.pprint(possible_keys)
['/Users/pasili001/.ssh/id_ed25519',
 '/Users/pasili001/.ssh/dkrz/id_ed25519',
 '/Users/pasili001/.ssh/dkrz/id_ed25519_dkrz',
 '/Users/pasili001/.ssh/hlrn/id_rsa_hlrn',
 '/Users/pasili001/.ssh/github/id_ed25519']
>>> # the complete list. 🙂
```

By reformulating the current logic for possible_keys, it shows all valid entries for ssh keys not just from top level folder but also from the sub-folders.