### PR TITLE
Bugfix #19: using os.path.commonpath yields desired result.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 files = setup.py
 commit = True
 tag = True

--- a/ptool/analyse.py
+++ b/ptool/analyse.py
@@ -22,7 +22,7 @@ def read_csv(filename, ignore=None, drop_duplicates=False):
     df = df.rename(columns={"fname": "fpath"})
     df = df[df.checksum != "-"]
     df["fname"] = df.fpath.apply(os.path.basename)
-    df["prefix"] = os.path.commonprefix(list(df.fpath.apply(os.path.dirname)))
+    df["prefix"] = os.path.commonpath(list(df.fpath.apply(os.path.dirname)))
     df["rpath"] = df.fpath.str.removeprefix(df.prefix[0])
     df["rparent"] = df.rpath.apply(os.path.dirname)
     for name, dtype in df.dtypes.items():

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="ptool",
-    version="0.2.0",
+    version="0.2.1",
     description="Analyse project data in pool directory at various sites",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -29,7 +29,7 @@ setup(
         ptool=ptool.cli:cli
     """,
     classifiers=[
-        "Development Status :: 0.2.0",
+        "Development Status :: 0.2.1",
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Fix the issue reported by Jan in here #19 

The bug was the result of using poor choice of function to get the common prefix among the paths.
`os.path.commonprefix` is replaced with `os.path.commonpath` which yields desired results.  